### PR TITLE
Off-white background implementation (ROOT)

### DIFF
--- a/src/root/cpp/include/DUNEStyle.h
+++ b/src/root/cpp/include/DUNEStyle.h
@@ -418,7 +418,17 @@ namespace dunestyle
 
     return ret;
   }
+  // ----------------------------------------------------------------------------
 
+  /// Change the background color to an off-white color (#f0f0f0) for use on updated DUNE slide (new template)
+
+  void Off_white_bkg()
+  {
+    static const TColor __off_white(TColor::GetFreeColorIndex(), 0.94, 0.94, 0.94);
+    gStyle->SetCanvasColor(__off_white);
+    gStyle->SetTitleFillColor(__off_white);
+    gStyle->SetStatColor(__off_white);
+  }
   // ----------------------------------------------------------------------------
   // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
To allow for seamless plots on the updated DUNE slides template, this adds the option to change the background color of plots to the same off-white (#f0f0f0) color.

Function is called off_white.bkg and would be called like the other dunestyle functions