### PR TITLE
Fix ROOT title box centring

### DIFF
--- a/src/root/cpp/include/DUNEStyle.h
+++ b/src/root/cpp/include/DUNEStyle.h
@@ -454,6 +454,7 @@ namespace dunestyle
     // Center title
     duneStyle->SetTitleAlign(22);
     duneStyle->SetTitleX(.5);
+    duneStyle->SetTitleW(1.);
     duneStyle->SetTitleY(.95);
     duneStyle->SetTitleBorderSize(0);
 


### PR DESCRIPTION
Without setting the title box width to the full canvas width, `duneStyle->SetTitleX(.5);` puts the left side of the title box in the middle, making your title nicely centred but only on the right side of the canvas like so:

<img width="1366" height="166" alt="Screenshot from 2026-04-24 20-56-42" src="https://github.com/user-attachments/assets/18792a82-77b9-4f6b-8ff7-e16aab2787a3" />
